### PR TITLE
TokensProvider (plural) -> TokenProvider (singular)

### DIFF
--- a/BlazorServerAuthWithAzureActiveDirectory/App.razor
+++ b/BlazorServerAuthWithAzureActiveDirectory/App.razor
@@ -1,5 +1,5 @@
 ﻿@using BlazorServerAuthWithAzureActiveDirectory.Data
-@inject TokenProvider TokensProvider
+@inject TokenProvider TokenProvider
 
 <CascadingAuthenticationState>
     <Router AppAssembly="@typeof(Program).Assembly">
@@ -19,8 +19,8 @@
 
     protected override Task OnInitializedAsync()
     {
-        TokensProvider.AccessToken = InitialState.AccessToken;
-        TokensProvider.RefreshToken = InitialState.RefreshToken;
+        TokenProvider.AccessToken = InitialState.AccessToken;
+        TokenProvider.RefreshToken = InitialState.RefreshToken;
 
         return base.OnInitializedAsync();
     }

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # Passing tokens to a server-side Blazor application
 
-* Authenticate your application as you would do with a regular mvc/razor pages application. 
-* Provision and save the tokens to the authentication cookie
-* Define a class to pass in the initial settings for the application:
+Authenticate your application as you would do with a regular mvc/razor pages application.
+
+Provision and save the tokens to the authentication cookie.
+
+Define a class to pass in the initial settings for the application:
+
 ```csharp
 namespace BlazorServerAuthWithAzureActiveDirectory.Data
 {
@@ -15,12 +18,9 @@ namespace BlazorServerAuthWithAzureActiveDirectory.Data
 }
 ```
 
-Define a **scoped** service that can be used within the Blazor application to resolve the settings from DI
-```csharp
-using System;
-using System.Security.Claims;
-using System.Threading.Tasks;
+Define a **scoped** service that can be used within the Blazor application to resolve the settings from DI:
 
+```csharp
 namespace BlazorServerAuthWithAzureActiveDirectory
 {
     public class TokenProvider
@@ -30,41 +30,45 @@ namespace BlazorServerAuthWithAzureActiveDirectory
     }
 }
 ```
-On startup
+
+On startup:
+
 ```csharp
 services.AddScoped<TokenProvider>();
 ```
 
-On the _Host cshtml, create and instance of InitialApplicationState and pass that as a parameter to the app:
+In *_Host cshtml*, create and instance of `InitialApplicationState` and pass that as a parameter to the app:
+
+```cshtml
+@{
+    var tokens = new InitialApplicationState
+    {
+        AccessToken = await HttpContext.GetTokenAsync("access_token"),
+        RefreshToken = await HttpContext.GetTokenAsync("refresh_token")
+    };
+}
+
+<app>
+    <component type="typeof(App)" param-InitialState="tokens" render-mode="ServerPrerendered" />
+</app>
 ```
-    @{
-        var tokens = new InitialApplicationState
-        {
-            AccessToken = await HttpContext.GetTokenAsync("access_token"),
-            RefreshToken = await HttpContext.GetTokenAsync("refresh_token")
-        };
-    }
 
+In the app component, resolve the service and initialize it with the data from the parameter:
 
-    <app>
-        <component type="typeof(App)" param-InitialState="tokens" render-mode="ServerPrerendered" />
-    </app>
-```
-
-On the app component resolve the service and initialize it with the data from the parameter
 ```razor
 @using BlazorServerAuthWithAzureActiveDirectory.Data
-@inject TokenProvider TokensProvider
-...
-@code{
-    [Parameter] public InitialApplicationState InitialState { get; set; }
+@inject TokenProvider TokenProvider
 
+...
+
+@code{
+    [Parameter]
+    public InitialApplicationState InitialState { get; set; }
 
     protected override Task OnInitializedAsync()
     {
-        TokensProvider.AccessToken = InitialState.AccessToken;
-        TokensProvider.RefreshToken = InitialState.RefreshToken;
-
+        TokenProvider.AccessToken = InitialState.AccessToken;
+        TokenProvider.RefreshToken = InitialState.RefreshToken;
 
         return base.OnInitializedAsync();
     }
@@ -72,11 +76,11 @@ On the app component resolve the service and initialize it with the data from th
 ```
 
 On your service, inject the token provider and retrieve the token to call the API:
+
 ```csharp
 public class WeatherForecastService
 {
     private readonly TokenProvider _store;
-
 
     public WeatherForecastService(IHttpClientFactory clientFactory, TokenProvider tokenProvider)
     {
@@ -84,9 +88,7 @@ public class WeatherForecastService
         _store = tokenProvider;
     }
 
-
     public HttpClient Client { get; }
-
 
     public async Task<WeatherForecast[]> GetForecastAsync(DateTime startDate)
     {
@@ -95,7 +97,6 @@ public class WeatherForecastService
         request.Headers.Add("Authorization", $"Bearer {token}");
         var response = await Client.SendAsync(request);
         response.EnsureSuccessStatusCode();
-
 
         return await response.Content.ReadAsAsync<WeatherForecast[]>();
     }


### PR DESCRIPTION
We need to keep this sample cross-linked in the docs just a bit longer. For the time being and for consistency, is it ok if this sample uses "TokenProvider" singular everywhere?